### PR TITLE
Fix npm trusted publishers with Node 24 and npm 11.6.2+

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,8 +17,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
+
+      - name: Update npm
+        run: npm install -g npm@^11.6.2
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,8 +15,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
+
+      - name: Update npm
+        run: npm install -g npm@^11.6.2
 
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oauth2-forwarder",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oauth2-forwarder",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "open": "^11.0.0"
@@ -20,7 +20,7 @@
         "@eslint/js": "^9.25.1",
         "@types/eslint__js": "^8.42.3",
         "@types/jest": "^30.0.0",
-        "@types/node": "^22.15.3",
+        "@types/node": "^24.0.0",
         "eslint": "^9.25.1",
         "jest": "^30.2.0",
         "prettier": "^3.5.3",
@@ -33,7 +33,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1687,13 +1687,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.18.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.13.tgz",
-      "integrity": "sha512-Bo45YKIjnmFtv6I1TuC8AaHBbqXtIo+Om5fE4QiU1Tj8QR/qt+8O3BAtOimG5IFmwaWiPmB3Mv3jtYzBA4Us2A==",
+      "version": "24.10.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
+      "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -6731,9 +6731,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "browser"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",
     "@types/eslint__js": "^8.42.3",
     "@types/jest": "^30.0.0",
-    "@types/node": "^22.15.3",
+    "@types/node": "^24.0.0",
     "eslint": "^9.25.1",
     "jest": "^30.2.0",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## Summary
- Upgrade all workflows to Node 24.x with npm@^11.6.2 to fix OIDC trusted publishers (per [npm/cli#8730](https://github.com/npm/cli/issues/8730))
- Switch from pnpm to npm across all workflows
- Update `@types/node` to ^24.0.0
- Update engines requirement to Node >=24.0.0

## Test plan
- [ ] Verify unit-tests workflow passes
- [ ] Verify npm publish workflow succeeds with trusted publishers