### PR TITLE
Make response_type optional in OAuth2 URL parsing with warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oauth2-forwarder",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oauth2-forwarder",
-      "version": "1.4.7",
+      "version": "1.4.8",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.5",
@@ -4324,9 +4324,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2-forwarder",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "utilities for forwarding oauth2 interactive flow (e.g. container to host)",
   "main": "dist/index.js",
   "bin": {

--- a/src/__tests__/parseOauth2Url.test.ts
+++ b/src/__tests__/parseOauth2Url.test.ts
@@ -1,5 +1,17 @@
+import { Logger } from "../logger"
 import { parseOauth2Url } from "../parseOauth2Url"
 import { Result } from "../result"
+
+function buildMockLogger(): Logger & { warnings: string[] } {
+  const warnings: string[] = []
+  return {
+    warnings,
+    error: () => {},
+    warn: (msg: string) => warnings.push(msg),
+    info: () => {},
+    debug: () => {}
+  }
+}
 
 describe("parseOauth2Url", () => {
   it("properly parses a valid url with all required parameters", () => {
@@ -109,6 +121,35 @@ describe("parseOauth2Url", () => {
       expect("code_challenge" in parseResult.value).toBe(false)
       expect("code_challenge_method" in parseResult.value).toBe(false)
     }
+  })
+
+  it("succeeds without response_type but logs a warning", () => {
+    const url =
+      "https://app.hubspot.com/oauth/authorize?client_id=dd618c42-0bf7-490a-a44a-a9a864b6391f&redirect_uri=http%3A//localhost%3A9582/callback&scope=crm.objects.contacts.read"
+
+    const logger = buildMockLogger()
+    const parseResult = parseOauth2Url(url, logger)
+
+    expect(Result.isSuccess(parseResult)).toBe(true)
+    if (Result.isSuccess(parseResult)) {
+      expect(parseResult.value.client_id).toEqual(
+        "dd618c42-0bf7-490a-a44a-a9a864b6391f"
+      )
+      expect(parseResult.value.response_type).toBeUndefined()
+    }
+    expect(logger.warnings).toHaveLength(1)
+    expect(logger.warnings[0]).toContain("response_type")
+  })
+
+  it("does not log a warning when response_type is present", () => {
+    const url =
+      "https://login.example.com/oauth?client_id=test&scope=openid&redirect_uri=http://localhost:3000&response_type=code"
+
+    const logger = buildMockLogger()
+    const parseResult = parseOauth2Url(url, logger)
+
+    expect(Result.isSuccess(parseResult)).toBe(true)
+    expect(logger.warnings).toHaveLength(0)
   })
 
   it("fails when only code_challenge is present without code_challenge_method", () => {

--- a/src/oauth2-types.ts
+++ b/src/oauth2-types.ts
@@ -5,7 +5,7 @@
  */
 type Oauth2AuthCodeRequestBaseParams = {
   client_id: string
-  response_type: string
+  response_type?: string
   redirect_uri: string
   scope?: string
   response_mode?: "query" | "fragment" | "form_post"

--- a/src/parseOauth2Url.ts
+++ b/src/parseOauth2Url.ts
@@ -1,13 +1,15 @@
+import { Logger } from "./logger"
 import { Oauth2AuthCodeRequestParams } from "./oauth2-types"
 import { Result } from "./result"
 
 export function parseOauth2Url(
-  url: string | undefined
+  url: string | undefined,
+  logger?: Logger
 ): Result<Oauth2AuthCodeRequestParams> {
   if (!url) {
     return Result.failure(new Error("Url parameter was undefined"))
   }
-  const requiredParams = ["client_id", "response_type", "redirect_uri"]
+  const requiredParams = ["client_id", "redirect_uri"]
 
   let urlObj: URL
   try {
@@ -22,6 +24,13 @@ export function parseOauth2Url(
     if (!params[param]) {
       return Result.failure(new Error(`Missing required parameter: ${param}`))
     }
+  }
+
+  // Warn if response_type is missing (required by RFC 6749, but some providers omit it)
+  if (!params.response_type) {
+    logger?.warn(
+      "Missing response_type parameter. This is required by the OAuth2 spec (RFC 6749) but some providers omit it."
+    )
   }
 
   // Validate PKCE params: both must be present together or neither
@@ -78,7 +87,7 @@ export function parseOauth2Url(
   const parsedParams: Oauth2AuthCodeRequestParams = hasCodeChallenge
     ? {
         "client_id": params.client_id as string,
-        "response_type": params.response_type as string,
+        "response_type": params.response_type,
         "redirect_uri": params.redirect_uri as string,
         "scope": params.scope,
         "response_mode": params.response_mode as
@@ -102,7 +111,7 @@ export function parseOauth2Url(
       }
     : {
         "client_id": params.client_id as string,
-        "response_type": params.response_type as string,
+        "response_type": params.response_type,
         "redirect_uri": params.redirect_uri as string,
         "scope": params.scope,
         "response_mode": params.response_mode as

--- a/src/server/buildCredentialProxy.ts
+++ b/src/server/buildCredentialProxy.ts
@@ -146,7 +146,7 @@ export function buildCredentialProxy(deps: {
 
       let oauthParams: Oauth2AuthCodeRequestParams
       if ("url" in deserializedBody) {
-        const oauthParamsResponse = parseOauth2Url(deserializedBody.url)
+        const oauthParamsResponse = parseOauth2Url(deserializedBody.url, logger)
         if (Result.isFailure(oauthParamsResponse)) {
           logger.debug(`OAuth parse error: ${oauthParamsResponse.error.message}`)
           if (deps.passthrough) {


### PR DESCRIPTION
## Summary
This PR makes the `response_type` parameter optional when parsing OAuth2 authorization URLs, while adding a warning when it's missing. This accommodates OAuth2 providers that don't strictly follow RFC 6749 by omitting the response_type parameter.

## Key Changes
- **Made `response_type` optional**: Removed `response_type` from the required parameters list in `parseOauth2Url()` and updated the type definition to `response_type?: string`
- **Added logging support**: Added an optional `Logger` parameter to `parseOauth2Url()` to enable warning messages
- **Added warning for missing response_type**: When `response_type` is absent, the parser now logs a warning explaining that it's required by RFC 6749 but some providers omit it
- **Updated type casting**: Changed `response_type` casting from `as string` to allow `undefined` values in the returned parameters
- **Integrated logger in credential proxy**: Updated `buildCredentialProxy` to pass the logger instance to `parseOauth2Url()`

## Notable Implementation Details
- The parser still succeeds when `response_type` is missing, but logs a warning to alert developers to potential compatibility issues
- A mock logger utility was added to tests to verify warning behavior
- Two new test cases validate that warnings are logged only when `response_type` is absent

https://claude.ai/code/session_018PDLXbQu2vYL191rEuMDck