### PR TITLE
Support OAuth2 response_mode=form_post callback delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Both `o2f-server` and `o2f-client` support the following command line options:
 Example:
 ```bash
 o2f-server --version
-# Output: o2f-server v1.4.10
+# Output: o2f-server v1.5.0
 ```
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ This utility works by changing the flow above as follows using a client-server p
 2. [container] `o2f-client` intercepts the request and forwards the url to `o2f-server` over a custom tcp port
 3. [host] `o2f-server` receives the request sends the the login url to the browser and simultaneously opens an http service to listen for the redirect response
 4. [host] The browser opens the login url and the user performs interactive authentication.
-5. [host] The successful interactive authentication results in a redirect GET request being made with the new authentication code.
-6. [host] The http service setup by `o2f-server` receives the redirect requests, extracts the code, and sends it back to `o2f-client` using the tcp channel opened in step 2.
-7. [container] `o2f-client` makes a GET requested for the redirect url it just received.
+5. [host] The successful interactive authentication results in a redirect request being made with the new authentication code. Most providers send a GET with the code as a query parameter; some (e.g. Azure / MSAL using `response_mode=form_post`) send a POST with an `application/x-www-form-urlencoded` body. Both are supported.
+6. [host] The http service setup by `o2f-server` receives the redirect request, captures the method, body, and content-type as needed, and sends them back to `o2f-client` using the tcp channel opened in step 2.
+7. [container] `o2f-client` replays the same request (GET or POST) against the local redirect url.
 8. [container] The http service setup by the CLI tool receives the redirect requests, extracts the code, and uses it.
 
 ## Installation and Usage
@@ -259,7 +259,7 @@ Both `o2f-server` and `o2f-client` support the following command line options:
 Example:
 ```bash
 o2f-server --version
-# Output: o2f-server v1.4.2
+# Output: o2f-server v1.4.10
 ```
 
 ## Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oauth2-forwarder",
-  "version": "1.4.10",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oauth2-forwarder",
-      "version": "1.4.10",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oauth2-forwarder",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oauth2-forwarder",
-      "version": "1.4.9",
+      "version": "1.4.10",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2-forwarder",
-  "version": "1.4.10",
+  "version": "1.5.0",
   "description": "utilities for forwarding oauth2 interactive flow (e.g. container to host)",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2-forwarder",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "utilities for forwarding oauth2 interactive flow (e.g. container to host)",
   "main": "dist/index.js",
   "bin": {

--- a/src/__tests__/all.e2e.ts
+++ b/src/__tests__/all.e2e.ts
@@ -1,5 +1,6 @@
 import {
   createTestHarness,
+  createTestHarnessWithCustomContainer,
   createMockContainer,
   getNextPort,
   sendRawRequest,
@@ -64,6 +65,79 @@ describe("happy path", () => {
     expect(harness.didFail()).toBe(false)
     const url = new URL(harness.getRedirectUrl())
     expect(url.searchParams.get("code")).toEqual(TEST_CODE)
+  })
+
+  it("roundtrips OAuth code via response_mode=form_post", async () => {
+    // Simulates the Azure CLI flow: Microsoft delivers the auth code as a
+    // POST with application/x-www-form-urlencoded body instead of as URL
+    // query parameters.
+    const serverPort = getNextPort()
+    const redirectPort = getNextPort()
+
+    // The client-side redirect should hit a real container and replay the
+    // form_post POST; verify the container actually sees a POST with the
+    // expected body.
+    let receivedMethod: string | undefined
+    let receivedContentType: string | undefined
+    let receivedBody: string | undefined
+
+    const harness = createTestHarnessWithCustomContainer({
+      port: serverPort,
+      callbackParams: { code: TEST_CODE, state: TEST_STATE },
+      containerPort: redirectPort,
+      formPost: true,
+      onContainerRequest: req => {
+        receivedMethod = req.method
+        receivedContentType = req.contentType
+        receivedBody = req.body
+      },
+      containerStatusCode: 200,
+      containerBody: "<html>Authentication successful!</html>"
+    })
+
+    const { close } = await harness.server()
+    await harness.client(createTestUrl(redirectPort, "", true))
+    close()
+
+    expect(harness.didFail()).toBe(false)
+    const result = harness.getRedirectResult()
+    expect(result?.type).toBe("success")
+
+    expect(receivedMethod).toBe("POST")
+    expect(receivedContentType).toBe("application/x-www-form-urlencoded")
+    expect(receivedBody).toContain(`code=${TEST_CODE}`)
+    expect(receivedBody).toContain(`state=${TEST_STATE}`)
+  })
+
+  it("propagates 400 from form_post replay as an error result (regression)", async () => {
+    // This is the exact scenario from the bug report: with response_mode=form_post,
+    // an old/buggy forwarder would replay the callback as a GET with no body, and
+    // the local OAuth listener would return 400. Verify the round-trip now succeeds.
+    // We simulate the "buggy" listener by having the container return 400 for GET,
+    // and 200 only for POST with a body. The fix should produce a "success" because
+    // we POST the body through correctly.
+    const serverPort = getNextPort()
+    const redirectPort = getNextPort()
+
+    const harness = createTestHarnessWithCustomContainer({
+      port: serverPort,
+      callbackParams: { code: TEST_CODE },
+      containerPort: redirectPort,
+      formPost: true,
+      onContainerRequest: () => {},
+      // Only succeed when a non-empty POST body is received
+      respondBasedOnRequest: req =>
+        req.method === "POST" && req.body.includes("code=")
+          ? { statusCode: 200, body: "<html>OK</html>" }
+          : { statusCode: 400, body: "missing code" }
+    })
+
+    const { close } = await harness.server()
+    await harness.client(createTestUrl(redirectPort))
+    close()
+
+    expect(harness.didFail()).toBe(false)
+    expect(harness.getRedirectResult()?.type).toBe("success")
   })
 
   it("roundtrips code and state through callback path", async () => {
@@ -576,6 +650,75 @@ describe("error handling", () => {
   })
 })
 
+describe("server → client wire format for form_post", () => {
+  it("includes method/body/contentType in the JSON response when callback is POST", async () => {
+    const port = getNextPort()
+    const redirectPort = getNextPort()
+    const TEST_BODY = "code=abc&state=xyz&session_state=sss"
+    const TEST_CT = "application/x-www-form-urlencoded"
+
+    const harness = createTestHarness({
+      port,
+      interactiveLogin: async () => ({
+        callbackUrl: `http://localhost:${redirectPort}/`,
+        callbackMethod: "POST",
+        callbackBody: TEST_BODY,
+        callbackContentType: TEST_CT,
+        requestId: "test-form-post-id",
+        complete: () => {}
+      })
+    })
+
+    const { close } = await harness.server()
+    const response = await sendRawRequest(
+      port,
+      JSON.stringify({
+        url: `https://example.com/oauth?client_id=x&redirect_uri=http://localhost:${redirectPort}&response_type=code&scope=openid&code_challenge=${TEST_CODE_CHALLENGE}&code_challenge_method=S256&response_mode=form_post`
+      })
+    )
+    close()
+
+    expect(response.statusCode).toEqual(200)
+    const parsed = JSON.parse(response.body)
+    expect(parsed.method).toEqual("POST")
+    expect(parsed.body).toEqual(TEST_BODY)
+    expect(parsed.contentType).toEqual(TEST_CT)
+    expect(parsed.url).toEqual(`http://localhost:${redirectPort}/`)
+    expect(parsed.requestId).toEqual("test-form-post-id")
+  })
+
+  it("omits method/body/contentType when callback is GET (back-compat)", async () => {
+    const port = getNextPort()
+    const redirectPort = getNextPort()
+
+    const harness = createTestHarness({
+      port,
+      interactiveLogin: async () => ({
+        callbackUrl: `http://localhost:${redirectPort}/?code=abc`,
+        callbackMethod: "GET",
+        requestId: "test-get-id",
+        complete: () => {}
+      })
+    })
+
+    const { close } = await harness.server()
+    const response = await sendRawRequest(
+      port,
+      JSON.stringify({
+        url: `https://example.com/oauth?client_id=x&redirect_uri=http://localhost:${redirectPort}&response_type=code&scope=openid&code_challenge=${TEST_CODE_CHALLENGE}&code_challenge_method=S256`
+      })
+    )
+    close()
+
+    expect(response.statusCode).toEqual(200)
+    const parsed = JSON.parse(response.body)
+    expect(parsed.method).toBeUndefined()
+    expect(parsed.body).toBeUndefined()
+    expect(parsed.contentType).toBeUndefined()
+    expect(parsed.url).toEqual(`http://localhost:${redirectPort}/?code=abc`)
+  })
+})
+
 describe("/complete endpoint", () => {
   it("returns 400 for invalid JSON", async () => {
     const port = getNextPort()
@@ -676,6 +819,7 @@ describe("timeout handling", () => {
       capturedRequestId = requestId
       return {
         callbackUrl: `http://localhost:${_responsePort}?code=test`,
+        callbackMethod: "GET" as const,
         requestId,
         complete: () => {}
       }
@@ -736,6 +880,7 @@ describe("timeout handling", () => {
       capturedRequestId = requestId
       return {
         callbackUrl: `http://localhost:${_responsePort}?code=test`,
+        callbackMethod: "GET" as const,
         requestId,
         complete: () => {}
       }

--- a/src/__tests__/e2e-helpers.ts
+++ b/src/__tests__/e2e-helpers.ts
@@ -85,7 +85,7 @@ export function createMockContainer(
 }
 
 /**
- * Creates a mock that simulates browser OAuth callback
+ * Creates a mock that simulates browser OAuth callback (GET, response_mode=query).
  */
 export function createMockBrowserCallback(
   params: CallbackParams
@@ -109,6 +109,53 @@ export function createMockBrowserCallback(
         resolve()
       })
       req.on("error", e => reject(e.message))
+    })
+  }
+}
+
+/**
+ * Creates a mock that simulates a browser OAuth callback via response_mode=form_post.
+ * The OAuth provider POSTs the auth params as an application/x-www-form-urlencoded
+ * body to the redirect_uri, with no query parameters on the URL.
+ */
+export function createMockFormPostBrowserCallback(
+  params: CallbackParams
+): (requestUrl: string) => Promise<void> {
+  return async (requestUrl: string): Promise<void> => {
+    const paramsResult = parseOauth2Url(requestUrl)
+    if (Result.isFailure(paramsResult)) {
+      throw new Error("Invalid request url")
+    }
+    const redirectUrl = new URL(paramsResult.value.redirect_uri)
+    const formBody = new URLSearchParams()
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined) {
+        formBody.set(key, value)
+      }
+    })
+    const body = formBody.toString()
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: redirectUrl.hostname,
+          port: redirectUrl.port || 80,
+          path: redirectUrl.pathname + redirectUrl.search,
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Length": Buffer.byteLength(body)
+          }
+        },
+        () => {
+          // Response received - resolve immediately, don't wait for body.
+          // The browser response is now delayed until after completion,
+          // so we just need to trigger the callback request.
+          resolve()
+        }
+      )
+      req.on("error", e => reject(e.message))
+      req.write(body)
+      req.end()
     })
   }
 }
@@ -157,6 +204,59 @@ export function createMockBrowserCallbackWithCapture(
 }
 
 /**
+ * Creates a mock that simulates a form_post browser OAuth callback and
+ * captures the response.
+ */
+export function createMockFormPostBrowserCallbackWithCapture(
+  params: CallbackParams,
+  onResponse: (response: BrowserResponse) => void
+): (requestUrl: string) => Promise<void> {
+  return async (requestUrl: string): Promise<void> => {
+    const paramsResult = parseOauth2Url(requestUrl)
+    if (Result.isFailure(paramsResult)) {
+      throw new Error("Invalid request url")
+    }
+    const redirectUrl = new URL(paramsResult.value.redirect_uri)
+    const formBody = new URLSearchParams()
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined) {
+        formBody.set(key, value)
+      }
+    })
+    const body = formBody.toString()
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: redirectUrl.hostname,
+          port: redirectUrl.port || 80,
+          path: redirectUrl.pathname + redirectUrl.search,
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Length": Buffer.byteLength(body)
+          }
+        },
+        res => {
+          const chunks: Buffer[] = []
+          res.on("data", (chunk: Buffer) => chunks.push(chunk))
+          res.on("end", () => {
+            onResponse({
+              statusCode: res.statusCode ?? 0,
+              headers: res.headers,
+              body: Buffer.concat(chunks).toString("utf8")
+            })
+            resolve()
+          })
+        }
+      )
+      req.on("error", e => reject(e.message))
+      req.write(body)
+      req.end()
+    })
+  }
+}
+
+/**
  * Creates a mock interactiveLogin that doesn't bind to any port.
  * Used for container redirect tests where the mock container needs
  * to use the callback port.
@@ -166,10 +266,13 @@ function createMockInteractiveLogin(callbackParams: CallbackParams): (
   port: number
 ) => Promise<{
   callbackUrl: string
+  callbackMethod: "GET" | "POST"
+  callbackBody?: string
+  callbackContentType?: string
   requestId: string
   complete: (result: RedirectResult) => void
 }> {
-  return async (url: string, port: number) => {
+  return async (url: string, _port: number) => {
     const paramsResult = parseOauth2Url(url)
     if (Result.isFailure(paramsResult)) {
       throw new Error("Invalid OAuth URL")
@@ -187,6 +290,7 @@ function createMockInteractiveLogin(callbackParams: CallbackParams): (
 
     return {
       callbackUrl: callbackUrl.toString(),
+      callbackMethod: "GET" as const,
       requestId,
       complete: () => {
         // Mock complete - no actual browser to respond to
@@ -215,6 +319,9 @@ export function createTestHarness(options: {
     port: number
   ) => Promise<{
     callbackUrl: string
+    callbackMethod: "GET" | "POST"
+    callbackBody?: string
+    callbackContentType?: string
     requestId: string
     complete: (result: RedirectResult) => void
   }>
@@ -226,6 +333,10 @@ export function createTestHarness(options: {
   containerResponse?: ContainerResponse
   // Optional whitelist configuration for testing whitelist behavior
   whitelist?: WhitelistConfig
+  // When true, simulate response_mode=form_post: the browser POSTs the auth
+  // params as an application/x-www-form-urlencoded body instead of sending
+  // them as URL query parameters.
+  formPost?: boolean
 }): TestHarness {
   let capturedRedirectUrl = ""
   let capturedRedirectResult: RedirectResult | undefined
@@ -237,6 +348,9 @@ export function createTestHarness(options: {
     port: number
   ) => Promise<{
     callbackUrl: string
+    callbackMethod: "GET" | "POST"
+    callbackBody?: string
+    callbackContentType?: string
     requestId: string
     complete: (result: RedirectResult) => void
   }>
@@ -248,7 +362,9 @@ export function createTestHarness(options: {
     interactiveLogin = createMockInteractiveLogin(options.callbackParams)
   } else if (options.callbackParams) {
     // Regular tests: use real interactiveLogin with mock browser callback
-    const mockCallback = createMockBrowserCallback(options.callbackParams)
+    const mockCallback = options.formPost
+      ? createMockFormPostBrowserCallback(options.callbackParams)
+      : createMockBrowserCallback(options.callbackParams)
     interactiveLogin = buildInteractiveLogin({
       openBrowser: async url => {
         await mockCallback(url)
@@ -327,6 +443,203 @@ export function createTestHarness(options: {
       close: () => {
         serverClose()
         containerClose?.()
+      }
+    }
+  }
+
+  return {
+    server: wrappedServer,
+    client,
+    getRedirectUrl: () => capturedRedirectUrl,
+    getRedirectResult: () => capturedRedirectResult,
+    didFail: () => failed
+  }
+}
+
+type ContainerCapturedRequest = {
+  method: string
+  contentType?: string
+  body: string
+}
+
+/**
+ * Creates a real listening "container" (loopback server) that can capture
+ * incoming requests and respond either with a fixed status/body, or based
+ * on the captured request. Used to drive end-to-end tests where the real
+ * client redirect logic must perform a POST/GET against an actual TCP
+ * server.
+ */
+function createCapturingContainer(
+  port: number,
+  options: {
+    onRequest: (received: ContainerCapturedRequest) => void
+    respond: (received: ContainerCapturedRequest) => {
+      statusCode: number
+      body?: string
+      location?: string
+    }
+  }
+): Promise<{ close: () => void }> {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = []
+      req.on("data", (c: Buffer) => chunks.push(c))
+      req.on("end", () => {
+        const ct = req.headers["content-type"]
+        const received: ContainerCapturedRequest = {
+          method: req.method ?? "",
+          contentType: typeof ct === "string" ? ct : undefined,
+          body: Buffer.concat(chunks).toString("utf8")
+        }
+        options.onRequest(received)
+        const reply = options.respond(received)
+        if (reply.location) {
+          res.setHeader("Location", reply.location)
+        }
+        res.statusCode = reply.statusCode
+        res.end(reply.body ?? "")
+      })
+    })
+    server.listen(port, LOCALHOST, () => {
+      resolve({ close: () => server.close() })
+    })
+  })
+}
+
+/**
+ * Variant of createTestHarness that uses a *real* TCP listener on the
+ * configured container port to capture and inspect the client-side replay.
+ *
+ * To avoid port collisions with the server-side interactiveLogin temporary
+ * listener (which would also bind to the redirect_uri's port in a real run),
+ * this harness uses a mock interactiveLogin that doesn't bind to any port.
+ * That keeps the test focused on the *client-side* leg: server → client →
+ * container replay. The form_post body capture inside buildInteractiveLogin
+ * itself is covered by its own unit tests.
+ */
+export function createTestHarnessWithCustomContainer(options: {
+  port: number
+  callbackParams: CallbackParams
+  containerPort: number
+  formPost?: boolean
+  onContainerRequest: (received: ContainerCapturedRequest) => void
+  containerStatusCode?: number
+  containerBody?: string
+  respondBasedOnRequest?: (received: ContainerCapturedRequest) => {
+    statusCode: number
+    body?: string
+    location?: string
+  }
+}): TestHarness {
+  let capturedRedirectUrl = ""
+  let capturedRedirectResult: RedirectResult | undefined
+
+  // Mock interactiveLogin that synthesizes the InteractiveLoginResult the
+  // real server would produce after receiving either a GET or POST callback.
+  const mockInteractiveLogin = async (
+    url: string,
+    _port: number
+  ): Promise<{
+    callbackUrl: string
+    callbackMethod: "GET" | "POST"
+    callbackBody?: string
+    callbackContentType?: string
+    requestId: string
+    complete: (result: RedirectResult) => void
+  }> => {
+    const paramsResult = parseOauth2Url(url)
+    if (Result.isFailure(paramsResult)) {
+      throw new Error("Invalid OAuth URL")
+    }
+    const requestId = nanoid()
+
+    if (options.formPost) {
+      // form_post: callback URL has no query params; body carries the auth
+      // params; method is POST.
+      const formBody = new URLSearchParams()
+      Object.entries(options.callbackParams).forEach(([key, value]) => {
+        if (value !== undefined) {
+          formBody.set(key, value)
+        }
+      })
+      return {
+        callbackUrl: paramsResult.value.redirect_uri,
+        callbackMethod: "POST" as const,
+        callbackBody: formBody.toString(),
+        callbackContentType: "application/x-www-form-urlencoded",
+        requestId,
+        complete: () => {}
+      }
+    }
+
+    // query mode: params on URL, GET
+    const callbackUrl = new URL(paramsResult.value.redirect_uri)
+    Object.entries(options.callbackParams).forEach(([key, value]) => {
+      if (value !== undefined) {
+        callbackUrl.searchParams.set(key, value)
+      }
+    })
+    return {
+      callbackUrl: callbackUrl.toString(),
+      callbackMethod: "GET" as const,
+      requestId,
+      complete: () => {}
+    }
+  }
+
+  const server = buildCredentialProxy({
+    host: LOCALHOST,
+    port: options.port,
+    interactiveLogin: mockInteractiveLogin,
+    openBrowser: async () => {},
+    passthrough: false,
+    whitelist: DISABLED_WHITELIST,
+    logger: NO_OP_LOGGER
+  })
+
+  const redirect = buildRedirect({ logger: NO_OP_LOGGER })
+
+  const forwarder = buildCredentialForwarder({
+    host: LOCALHOST,
+    port: options.port,
+    redirect,
+    logger: NO_OP_LOGGER
+  })
+
+  let failed = false
+  const client = buildBrowserHelper({
+    onExit: {
+      success: () => {},
+      failure: () => {
+        failed = true
+      }
+    },
+    credentialForwarder: async (url: string) => {
+      const result = await forwarder(url)
+      capturedRedirectResult = result
+      if (result.type === "redirect") {
+        capturedRedirectUrl = result.location
+      }
+      return result
+    },
+    logger: NO_OP_LOGGER
+  })
+
+  const wrappedServer = async (): Promise<{ close: () => void }> => {
+    const container = await createCapturingContainer(options.containerPort, {
+      onRequest: options.onContainerRequest,
+      respond:
+        options.respondBasedOnRequest ??
+        (() => ({
+          statusCode: options.containerStatusCode ?? 200,
+          body: options.containerBody
+        }))
+    })
+    const { close: serverClose } = await server()
+    return {
+      close: () => {
+        serverClose()
+        container.close()
       }
     }
   }

--- a/src/client/__tests__/buildRedirect.test.ts
+++ b/src/client/__tests__/buildRedirect.test.ts
@@ -244,4 +244,260 @@ describe("buildRedirect", () => {
       expect(messages.some(m => m.includes("GET request"))).toBe(true)
     })
   })
+
+  describe("form_post (POST) replay", () => {
+    type CapturedRequest = {
+      method?: string
+      contentType?: string | string[]
+      body: string
+    }
+
+    const createCapturingServer = (
+      host: string,
+      responseCode: number,
+      onRequest: (received: CapturedRequest) => void,
+      options?: { location?: string; body?: string }
+    ): Promise<number> => {
+      return new Promise((resolve, reject) => {
+        server = http.createServer((req, res) => {
+          const chunks: Buffer[] = []
+          req.on("data", (chunk: Buffer) => chunks.push(chunk))
+          req.on("end", () => {
+            onRequest({
+              method: req.method,
+              contentType: req.headers["content-type"],
+              body: Buffer.concat(chunks).toString("utf8")
+            })
+            if (options?.location) {
+              res.setHeader("Location", options.location)
+            }
+            res.statusCode = responseCode
+            res.end(options?.body ?? "")
+          })
+        })
+        server.on("error", reject)
+        server.listen(0, host, () => {
+          if (!server) {
+            reject(new Error("Server not initialized"))
+            return
+          }
+          const address = server.address()
+          if (address && typeof address === "object") {
+            resolve(address.port)
+          } else {
+            reject(new Error("Failed to get server port"))
+          }
+        })
+      })
+    }
+
+    it("sends POST with form body when method=POST", async () => {
+      let captured: CapturedRequest | undefined
+      serverPort = await createCapturingServer("127.0.0.1", 200, r => {
+        captured = r
+      })
+      const redirect = buildRedirect({ logger: buildNoOpLogger() })
+
+      const body = "code=abc123&state=xyz&session_state=def"
+      const result = await redirect(`http://127.0.0.1:${serverPort}/`, {
+        method: "POST",
+        body,
+        contentType: "application/x-www-form-urlencoded"
+      })
+
+      expect(result.type).toBe("success")
+      expect(captured?.method).toBe("POST")
+      expect(captured?.contentType).toBe("application/x-www-form-urlencoded")
+      expect(captured?.body).toBe(body)
+    })
+
+    it("defaults Content-Type to application/x-www-form-urlencoded if omitted", async () => {
+      let captured: CapturedRequest | undefined
+      serverPort = await createCapturingServer("127.0.0.1", 200, r => {
+        captured = r
+      })
+      const redirect = buildRedirect({ logger: buildNoOpLogger() })
+
+      await redirect(`http://127.0.0.1:${serverPort}/`, {
+        method: "POST",
+        body: "code=abc"
+      })
+
+      expect(captured?.contentType).toBe("application/x-www-form-urlencoded")
+    })
+
+    it("uses GET when no options are provided (back-compat)", async () => {
+      let captured: CapturedRequest | undefined
+      serverPort = await createCapturingServer("127.0.0.1", 200, r => {
+        captured = r
+      })
+      const redirect = buildRedirect({ logger: buildNoOpLogger() })
+
+      await redirect(`http://127.0.0.1:${serverPort}/?code=abc`)
+
+      expect(captured?.method).toBe("GET")
+      expect(captured?.body).toBe("")
+    })
+
+    it("does not send a body when method=GET", async () => {
+      let captured: CapturedRequest | undefined
+      serverPort = await createCapturingServer("127.0.0.1", 200, r => {
+        captured = r
+      })
+      const redirect = buildRedirect({ logger: buildNoOpLogger() })
+
+      await redirect(`http://127.0.0.1:${serverPort}/?code=abc`, {
+        method: "GET",
+        body: "should-be-ignored"
+      })
+
+      expect(captured?.method).toBe("GET")
+      expect(captured?.body).toBe("")
+    })
+
+    it("switches to GET on loopback redirect (does not replay POST body)", async () => {
+      // First server: receives initial POST and 302-redirects to a second server.
+      // Second server: must receive a GET with no body.
+      let secondRequest: CapturedRequest | undefined
+      const secondServer = await new Promise<{
+        port: number
+        close: () => void
+      }>((resolve, reject) => {
+        const s = http.createServer((req, res) => {
+          const chunks: Buffer[] = []
+          req.on("data", (c: Buffer) => chunks.push(c))
+          req.on("end", () => {
+            secondRequest = {
+              method: req.method,
+              contentType: req.headers["content-type"],
+              body: Buffer.concat(chunks).toString("utf8")
+            }
+            res.statusCode = 200
+            res.end("done")
+          })
+        })
+        s.on("error", reject)
+        s.listen(0, "127.0.0.1", () => {
+          const address = s.address()
+          if (address && typeof address === "object") {
+            resolve({ port: address.port, close: () => s.close() })
+          } else {
+            reject(new Error("Failed to get port"))
+          }
+        })
+      })
+
+      let firstRequest: CapturedRequest | undefined
+      try {
+        serverPort = await createCapturingServer(
+          "127.0.0.1",
+          302,
+          r => {
+            firstRequest = r
+          },
+          { location: `http://127.0.0.1:${secondServer.port}/next` }
+        )
+        const redirect = buildRedirect({ logger: buildNoOpLogger() })
+
+        const result = await redirect(`http://127.0.0.1:${serverPort}/`, {
+          method: "POST",
+          body: "code=abc",
+          contentType: "application/x-www-form-urlencoded"
+        })
+
+        expect(result.type).toBe("success")
+        expect(firstRequest?.method).toBe("POST")
+        expect(firstRequest?.body).toBe("code=abc")
+        // After loopback 302 we should be using GET with no body.
+        expect(secondRequest?.method).toBe("GET")
+        expect(secondRequest?.body).toBe("")
+      } finally {
+        secondServer.close()
+      }
+    })
+
+    it("returns 'redirect' for non-loopback 302 (POST body not replayed externally)", async () => {
+      const externalUrl = "https://example.com/success"
+      let captured: CapturedRequest | undefined
+      serverPort = await createCapturingServer(
+        "127.0.0.1",
+        302,
+        r => {
+          captured = r
+        },
+        { location: externalUrl }
+      )
+      const redirect = buildRedirect({ logger: buildNoOpLogger() })
+
+      const result = await redirect(`http://127.0.0.1:${serverPort}/`, {
+        method: "POST",
+        body: "code=abc",
+        contentType: "application/x-www-form-urlencoded"
+      })
+
+      expect(result.type).toBe("redirect")
+      if (result.type === "redirect") {
+        expect(result.location).toBe(externalUrl)
+      }
+      expect(captured?.method).toBe("POST")
+      expect(captured?.body).toBe("code=abc")
+    })
+
+    it("propagates the POST 400 status as an error (regression: form_post mishandling)", async () => {
+      serverPort = await createCapturingServer("127.0.0.1", 400, () => {})
+      const redirect = buildRedirect({ logger: buildNoOpLogger() })
+
+      const result = await redirect(`http://127.0.0.1:${serverPort}/`, {
+        method: "POST",
+        body: "code=abc",
+        contentType: "application/x-www-form-urlencoded"
+      })
+
+      expect(result.type).toBe("error")
+      if (result.type === "error") {
+        expect(result.message).toMatch(/unexpected status.*400/i)
+      }
+    })
+
+    it("sets Content-Length matching the body byte length", async () => {
+      let receivedContentLength: string | undefined
+      await new Promise<void>((resolve, reject) => {
+        server = http.createServer((req, res) => {
+          receivedContentLength = req.headers["content-length"]
+          // Drain the body so the request finishes
+          req.on("data", () => {})
+          req.on("end", () => {
+            res.statusCode = 200
+            res.end()
+          })
+        })
+        server.on("error", reject)
+        server.listen(0, "127.0.0.1", () => {
+          if (!server) {
+            reject(new Error("Server not initialized"))
+            return
+          }
+          const address = server.address()
+          if (address && typeof address === "object") {
+            serverPort = address.port
+            resolve()
+          } else {
+            reject(new Error("Failed to get server port"))
+          }
+        })
+      })
+
+      const body = "code=héllo"
+      const redirect = buildRedirect({ logger: buildNoOpLogger() })
+      const result = await redirect(`http://127.0.0.1:${serverPort}/`, {
+        method: "POST",
+        body
+      })
+
+      expect(result.type).toBe("success")
+      expect(receivedContentLength).toBe(
+        String(Buffer.byteLength(body, "utf8"))
+      )
+    })
+  })
 })

--- a/src/client/buildCredentialForwarder.ts
+++ b/src/client/buildCredentialForwarder.ts
@@ -1,18 +1,31 @@
 import http from "http"
-import { CompletionReport, RedirectResult } from "../redirect-types"
+import {
+  CompletionReport,
+  RedirectResult,
+  RedirectRequestOptions
+} from "../redirect-types"
 import { type Logger } from "../logger"
 
 export function buildCredentialForwarder(deps: {
   host: string
   port: number
-  redirect: (url: string) => Promise<RedirectResult>
+  redirect: (
+    url: string,
+    options?: RedirectRequestOptions
+  ) => Promise<RedirectResult>
   logger: Logger
 }): (url: string) => Promise<RedirectResult> {
   const { logger } = deps
 
   const sendOauth2Request = (
     url: string
-  ): Promise<{ redirectUrl: string; requestId: string }> => {
+  ): Promise<{
+    redirectUrl: string
+    requestId: string
+    method?: "GET" | "POST"
+    body?: string
+    contentType?: string
+  }> => {
     return new Promise((resolve, reject) => {
       const requestOptions: http.RequestOptions = {
         path: "/",
@@ -56,9 +69,19 @@ export function buildCredentialForwarder(deps: {
             reject("Response did not contain 'requestId' property")
             return
           }
+          const method = outputSerialized.method === "POST" ? "POST" : undefined
           resolve({
             redirectUrl: outputSerialized.url,
-            requestId: outputSerialized.requestId
+            requestId: outputSerialized.requestId,
+            method,
+            body:
+              typeof outputSerialized.body === "string"
+                ? outputSerialized.body
+                : undefined,
+            contentType:
+              typeof outputSerialized.contentType === "string"
+                ? outputSerialized.contentType
+                : undefined
           })
         })
         res.on("close", () => {
@@ -129,12 +152,22 @@ export function buildCredentialForwarder(deps: {
   return async url => {
     // Step 1: Send OAuth2 URL to server
     logger.debug(`Starting credential forwarding for URL: "${url}"`)
-    const { redirectUrl, requestId } = await sendOauth2Request(url)
-    logger.debug(`Received redirectUrl: "${redirectUrl}", requestId: "${requestId}"`)
+    const { redirectUrl, requestId, method, body, contentType } =
+      await sendOauth2Request(url)
+    logger.debug(
+      `Received redirectUrl: "${redirectUrl}", requestId: "${requestId}", method: "${method ?? "GET"}"`
+    )
 
     // Step 2: Perform the redirect (follows localhost redirects, returns non-localhost)
+    // For response_mode=form_post the server delivers method=POST plus the
+    // form-urlencoded body, so we replay the exact request the OAuth provider
+    // made — the local OAuth listener (e.g. MSAL) needs the original POST.
     logger.debug(`Performing redirect to: "${redirectUrl}"`)
-    const result = await deps.redirect(redirectUrl)
+    const result = await deps.redirect(redirectUrl, {
+      method: method ?? "GET",
+      body,
+      contentType
+    })
     logger.debug(`Redirect result type: "${result.type}"`)
 
     // Step 3: Send completion report to server

--- a/src/client/buildRedirect.ts
+++ b/src/client/buildRedirect.ts
@@ -1,6 +1,6 @@
 import http from "http"
 import { isLoopbackUrl, convertLoopbackUrl } from "../loopback"
-import { RedirectResult } from "../redirect-types"
+import { RedirectResult, RedirectRequestOptions } from "../redirect-types"
 import { type Logger } from "../logger"
 
 const MAX_REDIRECTS = 10
@@ -13,18 +13,26 @@ type RequestResult = {
 }
 
 /**
- * Makes an HTTP GET request to the given URL and returns the result.
+ * Makes an HTTP request to the given URL and returns the result.
  * For loopback URLs, implements RFC 8252 best practice of trying both
  * IPv4 (127.0.0.1) and IPv6 ([::1]) addresses to handle cases where
  * servers may bind to one or the other.
+ *
+ * Supports both GET (response_mode=query) and POST (response_mode=form_post)
+ * callback replay.
  */
 export function buildRedirect(deps: {
   logger: Logger
-}): (url: string) => Promise<RedirectResult> {
+}): (url: string, options?: RedirectRequestOptions) => Promise<RedirectResult> {
   const { logger } = deps
 
   const makeRequest = (
     url: string,
+    requestOptions: {
+      method: "GET" | "POST"
+      body?: string
+      contentType?: string
+    },
     hostHeader?: string
   ): Promise<RequestResult> => {
     return new Promise((resolve, reject) => {
@@ -36,15 +44,28 @@ export function buildRedirect(deps: {
       // Strip brackets from IPv6 addresses - URL.hostname returns "[::1]" but
       // http.request expects "::1"
       const hostname = parsedUrl.hostname.replace(/^\[|\]$/g, "")
+      const headers: http.OutgoingHttpHeaders = {}
+      if (hostHeader) {
+        headers.Host = hostHeader
+      }
+
+      const bodyBuffer =
+        requestOptions.method === "POST" && requestOptions.body !== undefined
+          ? Buffer.from(requestOptions.body, "utf8")
+          : undefined
+
+      if (bodyBuffer) {
+        headers["Content-Length"] = bodyBuffer.length
+        headers["Content-Type"] =
+          requestOptions.contentType ?? "application/x-www-form-urlencoded"
+      }
+
       const options: http.RequestOptions = {
         hostname,
         port: parsedUrl.port || 80,
         path: parsedUrl.pathname + parsedUrl.search,
-        method: "GET"
-      }
-
-      if (hostHeader) {
-        options.headers = { Host: hostHeader }
+        method: requestOptions.method,
+        headers
       }
 
       const req = http.request(options, res => {
@@ -76,12 +97,20 @@ export function buildRedirect(deps: {
         reject(error)
       })
 
+      if (bodyBuffer) {
+        req.write(bodyBuffer)
+      }
       req.end()
     })
   }
 
   const makeRequestWithLoopbackFallback = async (
-    url: string
+    url: string,
+    requestOptions: {
+      method: "GET" | "POST"
+      body?: string
+      contentType?: string
+    }
   ): Promise<RequestResult> => {
     if (isLoopbackUrl(url)) {
       // Preserve the original host for the Host header (e.g., "localhost:8080")
@@ -94,13 +123,13 @@ export function buildRedirect(deps: {
       logger.debug(`Preserving original Host header: ${originalHost}`)
       try {
         logger.debug(`Trying IPv4: ${ipv4Url}`)
-        return await makeRequest(ipv4Url, originalHost)
+        return await makeRequest(ipv4Url, requestOptions, originalHost)
       } catch (ipv4Error) {
         const err = ipv4Error as NodeJS.ErrnoException
         if (err.code === "ECONNREFUSED") {
           logger.debug(`IPv4 connection refused, trying IPv6: ${ipv6Url}`)
           try {
-            return await makeRequest(ipv6Url, originalHost)
+            return await makeRequest(ipv6Url, requestOptions, originalHost)
           } catch (ipv6Error) {
             const err6 = ipv6Error as NodeJS.ErrnoException
             throw new Error(
@@ -112,15 +141,20 @@ export function buildRedirect(deps: {
         throw ipv4Error
       }
     }
-    return await makeRequest(url)
+    return await makeRequest(url, requestOptions)
   }
 
   const followRedirects = async (
     url: string,
+    requestOptions: {
+      method: "GET" | "POST"
+      body?: string
+      contentType?: string
+    },
     remainingRedirects: number
   ): Promise<RedirectResult> => {
     logger.debug(
-      `Making GET request to url: "${url}" (${remainingRedirects} redirects remaining)`
+      `Making ${requestOptions.method} request to url: "${url}" (${remainingRedirects} redirects remaining)`
     )
 
     if (remainingRedirects <= 0) {
@@ -132,7 +166,7 @@ export function buildRedirect(deps: {
 
     let result: RequestResult
     try {
-      result = await makeRequestWithLoopbackFallback(url)
+      result = await makeRequestWithLoopbackFallback(url, requestOptions)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       return { type: "error", message }
@@ -151,10 +185,17 @@ export function buildRedirect(deps: {
 
       logger.debug(`Redirect to: ${location}`)
 
-      // If redirect is to a loopback URL, follow it
+      // If redirect is to a loopback URL, follow it.
+      // Per common HTTP semantics (and how browsers handle 301/302 from POST),
+      // we switch to a GET and drop the body when following a redirect chain.
+      // The body only applied to the initial callback to the OAuth listener.
       if (isLoopbackUrl(location)) {
         logger.debug(`Following localhost redirect`)
-        return followRedirects(location, remainingRedirects - 1)
+        return followRedirects(
+          location,
+          { method: "GET" },
+          remainingRedirects - 1
+        )
       }
 
       // Non-localhost redirect: return it for the server to forward to browser
@@ -172,5 +213,14 @@ export function buildRedirect(deps: {
     }
   }
 
-  return url => followRedirects(url, MAX_REDIRECTS)
+  return (url, options) =>
+    followRedirects(
+      url,
+      {
+        method: options?.method ?? "GET",
+        body: options?.body,
+        contentType: options?.contentType
+      },
+      MAX_REDIRECTS
+    )
 }

--- a/src/redirect-types.ts
+++ b/src/redirect-types.ts
@@ -7,3 +7,15 @@ export type CompletionReport = {
   requestId: string
   result: RedirectResult
 }
+
+/**
+ * Options for replaying an OAuth2 callback against the in-container loopback
+ * server. When the OAuth provider used response_mode=form_post, the callback
+ * arrives as an HTTP POST with form-urlencoded body, and we need to replay it
+ * the same way (per RFC 6749 §4.1.2 / OAuth 2.0 Form Post Response Mode).
+ */
+export type RedirectRequestOptions = {
+  method?: "GET" | "POST"
+  body?: string
+  contentType?: string
+}

--- a/src/server/__tests__/buildInteractiveLogin.test.ts
+++ b/src/server/__tests__/buildInteractiveLogin.test.ts
@@ -196,39 +196,68 @@ describe("buildInteractiveLogin — callback capture", () => {
 
   it("ignores follow-up requests on the same keep-alive connection without re-resolving", async () => {
     // This is the favicon/prefetch scenario observed in the real failure log.
-    // After the first callback, the listening socket is closed but the
-    // browser may pipeline additional requests on the keep-alive connection.
+    // After the first callback the listening socket is closed via
+    // server.close(), but existing keep-alive connections stay open and the
+    // browser can pipeline another request (favicon, prefetch, etc.) on the
+    // same connection. The handler must respond to those without resolving
+    // the promise a second time.
     const port = await getRandomPort()
+    const agent = new http.Agent({ keepAlive: true })
+
+    const sendRequest = (
+      path: string
+    ): Promise<{ status: number; body: string }> =>
+      new Promise((resolve, reject) => {
+        const req = http.request(
+          { hostname: LOCALHOST, port, path, method: "GET", agent },
+          res => {
+            const chunks: Buffer[] = []
+            res.on("data", (c: Buffer) => chunks.push(c))
+            res.on("end", () =>
+              resolve({
+                status: res.statusCode ?? 0,
+                body: Buffer.concat(chunks).toString("utf8")
+              })
+            )
+          }
+        )
+        req.on("error", reject)
+        req.end()
+      })
+
+    let firstRequestPromise:
+      | Promise<{ status: number; body: string }>
+      | undefined
 
     const interactiveLogin = buildInteractiveLogin({
       openBrowser: async () => {
-        // Send the real callback first.
-        const agent = new http.Agent({ keepAlive: true })
-        await new Promise<void>((resolve, reject) => {
-          const req = http.request(
-            {
-              hostname: LOCALHOST,
-              port,
-              path: "/?code=abc",
-              method: "GET",
-              agent
-            },
-            res => {
-              res.on("data", () => {})
-              res.on("end", () => resolve())
-            }
-          )
-          req.on("error", reject)
-          req.end()
-        })
-        agent.destroy()
+        // Kick off the initial callback. Don't await it here — the server's
+        // response is held pending complete(), which the test triggers below.
+        firstRequestPromise = sendRequest("/?code=abc")
       },
       logger: buildNoOpLogger()
     })
 
-    // Should resolve exactly once and not throw.
+    // First resolution.
     const result = await interactiveLogin(OAUTH_URL, port)
     expect(result.callbackMethod).toBe("GET")
+
+    // Release the held response for the first request so the keep-alive
+    // connection is free to carry a second request.
     result.complete({ type: "success" })
+    if (!firstRequestPromise) {
+      throw new Error("openBrowser did not initiate the first request")
+    }
+    const firstResult = await firstRequestPromise
+    expect(firstResult.status).toBe(200)
+
+    // Send a follow-up request on the SAME keep-alive agent. This simulates
+    // the browser fetching /favicon.ico on the connection it kept open from
+    // the first request. The follow-up must get a 404 — the original
+    // promise stays resolved exactly once.
+    const secondResult = await sendRequest("/favicon.ico")
+    expect(secondResult.status).toBe(404)
+
+    agent.destroy()
   })
 })

--- a/src/server/__tests__/buildInteractiveLogin.test.ts
+++ b/src/server/__tests__/buildInteractiveLogin.test.ts
@@ -1,0 +1,234 @@
+import http from "http"
+import net from "net"
+import { buildInteractiveLogin } from "../buildInteractiveLogin"
+import { buildNoOpLogger } from "../../__tests__/test-logger"
+
+const LOCALHOST = "127.0.0.1"
+
+const getRandomPort = (): Promise<number> => {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer()
+    srv.unref()
+    srv.on("error", reject)
+    srv.listen(0, LOCALHOST, () => {
+      const address = srv.address()
+      if (address && typeof address === "object") {
+        const port = address.port
+        srv.close(() => resolve(port))
+      } else {
+        srv.close()
+        reject(new Error("Could not get random port"))
+      }
+    })
+  })
+}
+
+const OAUTH_URL =
+  "https://example.com/oauth?client_id=test&redirect_uri=http://localhost:1&response_type=code&scope=openid"
+
+describe("buildInteractiveLogin — callback capture", () => {
+  it("returns callbackMethod='GET' for a query-mode callback", async () => {
+    const port = await getRandomPort()
+    const interactiveLogin = buildInteractiveLogin({
+      openBrowser: async () => {
+        // Simulate browser hitting the redirect URI as a GET with query params
+        await new Promise<void>((resolve, reject) => {
+          const req = http.request(
+            {
+              hostname: LOCALHOST,
+              port,
+              path: "/?code=abc&state=xyz",
+              method: "GET"
+            },
+            () => resolve()
+          )
+          req.on("error", reject)
+          req.end()
+        })
+      },
+      logger: buildNoOpLogger()
+    })
+
+    const result = await interactiveLogin(OAUTH_URL, port)
+
+    expect(result.callbackMethod).toBe("GET")
+    expect(result.callbackBody).toBeUndefined()
+    expect(result.callbackContentType).toBeUndefined()
+    expect(result.callbackUrl).toContain("/?code=abc&state=xyz")
+    result.complete({ type: "success" })
+  })
+
+  it("captures method, body, and Content-Type for a form_post callback", async () => {
+    const port = await getRandomPort()
+    const body =
+      "code=AUTHCODE&state=STATE123&client_info=CINFO&session_state=SESS"
+
+    const interactiveLogin = buildInteractiveLogin({
+      openBrowser: async () => {
+        // Simulate browser POSTing the auth response (response_mode=form_post)
+        await new Promise<void>((resolve, reject) => {
+          const req = http.request(
+            {
+              hostname: LOCALHOST,
+              port,
+              path: "/",
+              method: "POST",
+              headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Content-Length": Buffer.byteLength(body)
+              }
+            },
+            () => resolve()
+          )
+          req.on("error", reject)
+          req.write(body)
+          req.end()
+        })
+      },
+      logger: buildNoOpLogger()
+    })
+
+    const result = await interactiveLogin(OAUTH_URL, port)
+
+    expect(result.callbackMethod).toBe("POST")
+    expect(result.callbackBody).toBe(body)
+    expect(result.callbackContentType).toBe("application/x-www-form-urlencoded")
+    // The callback URL itself has no query params in form_post mode
+    expect(result.callbackUrl).toMatch(/\/$/)
+    result.complete({ type: "success" })
+  })
+
+  it("preserves the exact form_post body bytes (Buffer.concat, not chunk join)", async () => {
+    const port = await getRandomPort()
+    // Use a body containing utf-8 to verify we don't mangle bytes when chunks
+    // are split.
+    const body = "code=héllo&state=wörld"
+
+    const interactiveLogin = buildInteractiveLogin({
+      openBrowser: async () => {
+        await new Promise<void>((resolve, reject) => {
+          const req = http.request(
+            {
+              hostname: LOCALHOST,
+              port,
+              path: "/",
+              method: "POST",
+              headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Content-Length": Buffer.byteLength(body, "utf8")
+              }
+            },
+            () => resolve()
+          )
+          req.on("error", reject)
+          // Split into two writes to force multi-chunk parsing
+          const bytes = Buffer.from(body, "utf8")
+          req.write(bytes.subarray(0, 5))
+          req.write(bytes.subarray(5))
+          req.end()
+        })
+      },
+      logger: buildNoOpLogger()
+    })
+
+    const result = await interactiveLogin(OAUTH_URL, port)
+    expect(result.callbackBody).toBe(body)
+    result.complete({ type: "success" })
+  })
+
+  it("rejects on login timeout when no callback arrives", async () => {
+    const port = await getRandomPort()
+    const interactiveLogin = buildInteractiveLogin({
+      openBrowser: async () => {
+        // Never trigger a callback
+      },
+      logger: buildNoOpLogger(),
+      loginTimeoutMs: 50
+    })
+
+    await expect(interactiveLogin(OAUTH_URL, port)).rejects.toThrow(/timeout/i)
+  })
+
+  it("complete() responds 200 with default body when result is success", async () => {
+    const port = await getRandomPort()
+    let browserResponseBody = ""
+    let browserStatusCode = 0
+
+    const browserDone = new Promise<void>((resolve, reject) => {
+      // Pre-arm the browser callback so we can capture the held response
+      setImmediate(() => {
+        const req = http.request(
+          {
+            hostname: LOCALHOST,
+            port,
+            path: "/?code=abc",
+            method: "GET"
+          },
+          res => {
+            browserStatusCode = res.statusCode ?? 0
+            const chunks: Buffer[] = []
+            res.on("data", (c: Buffer) => chunks.push(c))
+            res.on("end", () => {
+              browserResponseBody = Buffer.concat(chunks).toString("utf8")
+              resolve()
+            })
+          }
+        )
+        req.on("error", reject)
+        req.end()
+      })
+    })
+
+    const interactiveLogin = buildInteractiveLogin({
+      openBrowser: async () => {
+        // browser is already arming on its own
+      },
+      logger: buildNoOpLogger()
+    })
+
+    const result = await interactiveLogin(OAUTH_URL, port)
+    result.complete({ type: "success" })
+    await browserDone
+
+    expect(browserStatusCode).toBe(200)
+    expect(browserResponseBody).toMatch(/Authentication completed/i)
+  })
+
+  it("ignores follow-up requests on the same keep-alive connection without re-resolving", async () => {
+    // This is the favicon/prefetch scenario observed in the real failure log.
+    // After the first callback, the listening socket is closed but the
+    // browser may pipeline additional requests on the keep-alive connection.
+    const port = await getRandomPort()
+
+    const interactiveLogin = buildInteractiveLogin({
+      openBrowser: async () => {
+        // Send the real callback first.
+        const agent = new http.Agent({ keepAlive: true })
+        await new Promise<void>((resolve, reject) => {
+          const req = http.request(
+            {
+              hostname: LOCALHOST,
+              port,
+              path: "/?code=abc",
+              method: "GET",
+              agent
+            },
+            res => {
+              res.on("data", () => {})
+              res.on("end", () => resolve())
+            }
+          )
+          req.on("error", reject)
+          req.end()
+        })
+        agent.destroy()
+      },
+      logger: buildNoOpLogger()
+    })
+
+    // Should resolve exactly once and not throw.
+    const result = await interactiveLogin(OAUTH_URL, port)
+    expect(result.callbackMethod).toBe("GET")
+    result.complete({ type: "success" })
+  })
+})

--- a/src/server/buildCredentialProxy.ts
+++ b/src/server/buildCredentialProxy.ts
@@ -50,7 +50,9 @@ export function buildCredentialProxy(deps: {
       }
       const hostname = getDomain(url) ?? "unknown"
       const reason = `Domain '${hostname}' is not in the whitelist`
-      const logPrefix = isPassthrough ? "Whitelist rejection (passthrough)" : "Whitelist rejection"
+      const logPrefix = isPassthrough
+        ? "Whitelist rejection (passthrough)"
+        : "Whitelist rejection"
       logger.warn(`${logPrefix}: ${reason}`)
       res.writeHead(403, reason)
       res.end()
@@ -125,7 +127,9 @@ export function buildCredentialProxy(deps: {
       clearTimeout(pending.timeoutId)
       pendingRequests.delete(report.requestId)
       logger.info(`Completed OAuth request for ${pending.domain}`)
-      logger.debug(`Request ${report.requestId} completed with result: ${report.result.type}`)
+      logger.debug(
+        `Request ${report.requestId} completed with result: ${report.result.type}`
+      )
       pending.complete(report.result)
 
       res.writeHead(200)
@@ -148,12 +152,15 @@ export function buildCredentialProxy(deps: {
       if ("url" in deserializedBody) {
         const oauthParamsResponse = parseOauth2Url(deserializedBody.url, logger)
         if (Result.isFailure(oauthParamsResponse)) {
-          logger.debug(`OAuth parse error: ${oauthParamsResponse.error.message}`)
+          logger.debug(
+            `OAuth parse error: ${oauthParamsResponse.error.message}`
+          )
           if (deps.passthrough) {
             if (rejectIfNotWhitelisted(deserializedBody.url, res, true)) {
               return
             }
-            const passthroughDomain = getDomain(deserializedBody.url) ?? "unknown"
+            const passthroughDomain =
+              getDomain(deserializedBody.url) ?? "unknown"
             logger.info(`Passthrough: opening ${passthroughDomain} in browser`)
             deps.openBrowser(deserializedBody.url).catch(err => {
               logger.error(`Failed to open browser: ${err}`)
@@ -212,30 +219,60 @@ export function buildCredentialProxy(deps: {
       logger.info(`Received OAuth request for ${domain}`)
       deps
         .interactiveLogin(deserializedBody.url, port)
-        .then(({ callbackUrl, requestId, complete }) => {
-          logger.debug(`Interactive login received callback, requestId: ${requestId}`)
-
-          // Store the completion handler with TTL timeout for cleanup
-          const timeoutId = setTimeout(() => {
-            logger.warn(
-              `Pending request ${requestId} expired after ${pendingRequestTtlMs}ms, cleaning up`
+        .then(
+          ({
+            callbackUrl,
+            callbackMethod,
+            callbackBody,
+            callbackContentType,
+            requestId,
+            complete
+          }) => {
+            logger.debug(
+              `Interactive login received callback, requestId: ${requestId}`
             )
-            pendingRequests.delete(requestId)
-          }, pendingRequestTtlMs)
 
-          pendingRequests.set(requestId, { complete, timeoutId, domain })
-          logger.debug(
-            `Stored pending request ${requestId} with TTL ${pendingRequestTtlMs}ms`
-          )
+            // Store the completion handler with TTL timeout for cleanup
+            const timeoutId = setTimeout(() => {
+              logger.warn(
+                `Pending request ${requestId} expired after ${pendingRequestTtlMs}ms, cleaning up`
+              )
+              pendingRequests.delete(requestId)
+            }, pendingRequestTtlMs)
 
-          logger.debug("Sending callback URL and requestId to client")
-          res.writeHead(200)
-          const responseBody = { url: callbackUrl, requestId }
-          logger.debug(
-            `Ending response with output: "${JSON.stringify(responseBody)}"`
-          )
-          res.end(JSON.stringify(responseBody))
-        })
+            pendingRequests.set(requestId, { complete, timeoutId, domain })
+            logger.debug(
+              `Stored pending request ${requestId} with TTL ${pendingRequestTtlMs}ms`
+            )
+
+            logger.debug("Sending callback URL and requestId to client")
+            res.writeHead(200)
+            const responseBody: {
+              url: string
+              requestId: string
+              method?: "GET" | "POST"
+              body?: string
+              contentType?: string
+            } = { url: callbackUrl, requestId }
+            // Only include the method/body fields when the callback was a POST
+            // (response_mode=form_post). Keeping the wire format minimal for
+            // the common GET case preserves backward compatibility with older
+            // clients that don't know about these fields.
+            if (callbackMethod === "POST") {
+              responseBody.method = "POST"
+              if (callbackBody !== undefined) {
+                responseBody.body = callbackBody
+              }
+              if (callbackContentType !== undefined) {
+                responseBody.contentType = callbackContentType
+              }
+            }
+            logger.debug(
+              `Ending response with output: "${JSON.stringify(responseBody)}"`
+            )
+            res.end(JSON.stringify(responseBody))
+          }
+        )
         .catch(error => {
           logger.error(`Interactive login error: "${JSON.stringify(error)}"`)
           res.writeHead(500, JSON.stringify(error))
@@ -249,7 +286,9 @@ export function buildCredentialProxy(deps: {
       close: () => {
         // Clear all pending request timeouts on shutdown
         for (const [requestId, pending] of pendingRequests) {
-          logger.debug(`Clearing pending request timeout for ${requestId} on shutdown`)
+          logger.debug(
+            `Clearing pending request timeout for ${requestId} on shutdown`
+          )
           clearTimeout(pending.timeoutId)
         }
         pendingRequests.clear()

--- a/src/server/buildCredentialProxy.ts
+++ b/src/server/buildCredentialProxy.ts
@@ -267,8 +267,27 @@ export function buildCredentialProxy(deps: {
                 responseBody.contentType = callbackContentType
               }
             }
+            // Don't log the serialized response body verbatim: for form_post
+            // callbacks it contains the raw OAuth form body (state,
+            // client_info, session_state, etc., and potentially tokens). The
+            // general log sanitizer only redacts `code`/`code_challenge`. Log
+            // a summary that omits the body content but preserves enough info
+            // for debugging.
+            const responseSummary = {
+              url: responseBody.url,
+              requestId: responseBody.requestId,
+              ...(responseBody.method !== undefined && {
+                method: responseBody.method
+              }),
+              ...(responseBody.contentType !== undefined && {
+                contentType: responseBody.contentType
+              }),
+              ...(responseBody.body !== undefined && {
+                bodyLength: responseBody.body.length
+              })
+            }
             logger.debug(
-              `Ending response with output: "${JSON.stringify(responseBody)}"`
+              `Ending response with output: ${JSON.stringify(responseSummary)}`
             )
             res.end(JSON.stringify(responseBody))
           }

--- a/src/server/buildInteractiveLogin.ts
+++ b/src/server/buildInteractiveLogin.ts
@@ -8,6 +8,22 @@ const DEFAULT_LOGIN_TIMEOUT_MS = 5 * 60 * 1000
 
 export type InteractiveLoginResult = {
   callbackUrl: string
+  /**
+   * HTTP method the OAuth provider used when delivering the callback.
+   * "GET" for response_mode=query (default), "POST" for response_mode=form_post.
+   */
+  callbackMethod: "GET" | "POST"
+  /**
+   * Raw request body when the callback arrived as a POST (form_post).
+   * Undefined for GET callbacks.
+   */
+  callbackBody?: string
+  /**
+   * Content-Type header from the inbound callback, if present. Forwarded so
+   * that the in-container loopback server (e.g. MSAL) sees the same media
+   * type the OAuth provider used (typically application/x-www-form-urlencoded).
+   */
+  callbackContentType?: string
   requestId: string
   complete: (result: RedirectResult) => void
 }
@@ -27,6 +43,7 @@ export function buildInteractiveLogin(deps: {
       logger.debug(`Generated requestId: ${requestId}`)
 
       let timeoutId: ReturnType<typeof setTimeout> | undefined
+      let resolved = false
 
       const server = http.createServer((req, res) => {
         // Clear timeout as soon as we receive a request
@@ -35,6 +52,8 @@ export function buildInteractiveLogin(deps: {
           timeoutId = undefined
         }
         logger.debug(`Received a ${req.method ?? "undefined"} request`)
+        const bodyChunks: Buffer[] = []
+
         req.on("error", error => {
           logger.error(`Request error: ${JSON.stringify(error)}`)
           res.writeHead(500, JSON.stringify(error))
@@ -43,8 +62,9 @@ export function buildInteractiveLogin(deps: {
           reject(error)
         })
 
-        req.on("data", chunk => {
-          logger.debug(`Received data chunk: ${chunk}`)
+        req.on("data", (chunk: Buffer) => {
+          bodyChunks.push(chunk)
+          logger.debug(`Received data chunk: ${chunk.toString("utf8")}`)
         })
 
         req.on("close", () => {
@@ -53,6 +73,17 @@ export function buildInteractiveLogin(deps: {
 
         req.on("end", () => {
           logger.debug("Request ended")
+
+          // After the first callback we've already resolved the promise and
+          // closed the listening socket. Some browsers reuse the underlying
+          // keep-alive connection for follow-up requests (favicon, prefetch,
+          // etc.); ignore those rather than re-resolving.
+          if (resolved) {
+            logger.debug("Ignoring follow-up request after callback resolved")
+            res.writeHead(404)
+            res.end()
+            return
+          }
 
           if (!req.headers.host) {
             const reason = "Missing Host header in redirect request"
@@ -64,13 +95,32 @@ export function buildInteractiveLogin(deps: {
             return
           }
           const callbackUrl = "http://" + req.headers.host + req.url
+          const method = (req.method ?? "GET").toUpperCase()
+          const callbackMethod: "GET" | "POST" =
+            method === "POST" ? "POST" : "GET"
+
+          let callbackBody: string | undefined
+          let callbackContentType: string | undefined
+          if (callbackMethod === "POST") {
+            callbackBody = Buffer.concat(bodyChunks).toString("utf8")
+            const ct = req.headers["content-type"]
+            if (typeof ct === "string") {
+              callbackContentType = ct
+            }
+            logger.debug(
+              `Captured form_post callback: contentType="${callbackContentType ?? "(none)"}", bodyLength=${callbackBody.length}`
+            )
+          }
 
           logger.debug(`Received callback url: "${callbackUrl}"`)
+          logger.debug(`Callback method: ${callbackMethod}`)
           logger.debug("Holding browser response pending completion")
 
           // Close the listening socket immediately to free the port
           // The existing connection (browser response) stays open
-          logger.debug("Closing listening socket (keeping response connection open)")
+          logger.debug(
+            "Closing listening socket (keeping response connection open)"
+          )
           server.close()
 
           // Create completion function that will respond to browser
@@ -99,18 +149,30 @@ export function buildInteractiveLogin(deps: {
                 break
 
               case "error":
-                logger.debug(`Sending error response to browser: ${result.message}`)
+                logger.debug(
+                  `Sending error response to browser: ${result.message}`
+                )
                 res.writeHead(500, { "Content-Type": "text/html" })
                 res.end(`Authentication failed: ${result.message}`)
                 break
             }
           }
 
-          resolve({ callbackUrl, requestId, complete })
+          resolved = true
+          resolve({
+            callbackUrl,
+            callbackMethod,
+            callbackBody,
+            callbackContentType,
+            requestId,
+            complete
+          })
         })
       })
 
-      logger.debug(`Starting temporary redirect server on port ${responsePort}...`)
+      logger.debug(
+        `Starting temporary redirect server on port ${responsePort}...`
+      )
       server.listen(responsePort, LOCALHOST, () => {
         logger.debug("Temporary redirect server is listening")
 

--- a/src/server/buildInteractiveLogin.ts
+++ b/src/server/buildInteractiveLogin.ts
@@ -64,7 +64,12 @@ export function buildInteractiveLogin(deps: {
 
         req.on("data", (chunk: Buffer) => {
           bodyChunks.push(chunk)
-          logger.debug(`Received data chunk: ${chunk.toString("utf8")}`)
+          // Don't log the chunk payload: with response_mode=form_post the body
+          // carries OAuth params (code, state, client_info, session_state,
+          // and in some flows tokens). The general log sanitizer only redacts
+          // `code`/`code_challenge`, so logging the raw chunk would leak the
+          // rest into debug logs.
+          logger.debug(`Received data chunk (${chunk.length} bytes)`)
         })
 
         req.on("close", () => {


### PR DESCRIPTION
## Summary
Add support for OAuth2 `response_mode=form_post` callback delivery, where the OAuth provider POSTs authentication parameters as a form-urlencoded body instead of sending them as URL query parameters. This enables compatibility with providers like Azure that use form_post mode.

## Key Changes

- **Server-side callback capture** (`buildInteractiveLogin.ts`):
  - Extended `InteractiveLoginResult` to include `callbackMethod`, `callbackBody`, and `callbackContentType` fields
  - Capture HTTP method, request body, and Content-Type header from incoming OAuth callbacks
  - Handle both GET (query mode) and POST (form_post mode) callbacks
  - Prevent re-resolution on keep-alive follow-up requests (favicon, prefetch, etc.)

- **Client-side callback replay** (`buildRedirect.ts`):
  - Added `RedirectRequestOptions` type to support POST requests with body and Content-Type
  - Implement POST request support with proper Content-Length header calculation
  - Maintain backward compatibility: default to GET when no options provided
  - Switch to GET on loopback redirects (don't replay POST body externally per RFC 8252)

- **Credential forwarding** (`buildCredentialForwarder.ts`):
  - Parse and forward `method`, `body`, and `contentType` from server response
  - Pass these options to the redirect function for proper callback replay

- **Server response** (`buildCredentialProxy.ts`):
  - Include callback method, body, and content-type in JSON response to client
  - Maintain backward compatibility by omitting these fields for GET callbacks

- **Test infrastructure** (`e2e-helpers.ts`):
  - Add `createMockFormPostBrowserCallback()` for simulating form_post callbacks
  - Add `createMockFormPostBrowserCallbackWithCapture()` for capturing responses
  - Add `createTestHarnessWithCustomContainer()` for end-to-end testing with real TCP listeners
  - Update `createMockInteractiveLogin()` to return callback method and body

- **Test coverage**:
  - New unit tests in `buildInteractiveLogin.test.ts` covering callback capture for both GET and POST
  - New tests in `buildRedirect.test.ts` for POST replay, Content-Length handling, and loopback redirect behavior
  - New e2e tests in `all.e2e.ts` for form_post roundtrip and error handling

## Implementation Details

- Form-urlencoded body bytes are properly preserved using `Buffer.concat()` to handle multi-chunk parsing
- Content-Length is calculated as byte length (UTF-8) to handle non-ASCII characters correctly
- Loopback redirects (302 responses to localhost) automatically switch to GET to comply with RFC 8252
- Non-loopback redirects (external URLs) return a "redirect" result without replaying the POST body
- Backward compatibility maintained: existing GET-based flows work unchanged

https://claude.ai/code/session_01EniVwaTmEdrYerezWCnnvr