### PR TITLE
ci(dependabot): add dependabot.yml for npm + github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# All dependencies are sourced from the public npm registry, so no `registries:`
+# block is defined here. Providing this explicit config also resolves the
+# "Private npm registries require ... configuration in dependabot.yml" error that
+# Dependabot's automatic GitHub Packages auth otherwise raises on this repo.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Batch routine version bumps into a single PR to reduce noise.
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Why

The most recent **Dependabot Updates** run ([run 28268289235](https://github.com/sam-mfb/oauth2-forwarder/actions/runs/28268289235)) — a security update for `vitest` — failed during file fetching with:

> Private npm registries require either a `.npmrc` file in your repository, or explicit `scope`/`replaces-base` configuration in `dependabot.yml`. Registry: `npm.pkg.github.com`

Dependabot's automatic GitHub Packages auth injected an `npm.pkg.github.com` credential, but the repo had **no `.npmrc` and no `.github/dependabot.yml`**, so Dependabot had a private-registry credential with no scope mapping and aborted before doing any work. (Build, unit tests, e2e tests, and the v1.5.1 NPM publish all passed — only the Dependabot job failed.)

## What

Adds `.github/dependabot.yml` declaring two ecosystems:

- **npm** (`/`, weekly) — routine version bumps grouped into a single PR to reduce noise.
- **github-actions** (`/`, weekly) — keeps workflow action versions current.

No `registries:` block is included since all dependencies come from the public npm registry. Providing this explicit config satisfies the requirement that was causing the file-fetch abort.

## Notes

- This only governs Dependabot behavior — no changes to build/test/publish workflows.
- Security updates are toggled separately in repo settings, but the same config now applies, so the next `vitest` security-update job should fetch files successfully.