### PR TITLE
chore(deps): upgrade typescript to 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "prettier": "^3.9.4",
         "rimraf": "^6.0.1",
         "ts-loader": "^9.5.2",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.1",
         "vitest": "^3.2.6",
         "webpack": "^5.108.3",
@@ -3979,9 +3979,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier": "^3.9.4",
     "rimraf": "^6.0.1",
     "ts-loader": "^9.5.2",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.1",
     "vitest": "^3.2.6",
     "webpack": "^5.108.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "lib": ["esnext"],
     "module": "CommonJS",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "types": ["node", "vitest/globals"],
     "noEmit": true,
     "skipLibCheck": true


### PR DESCRIPTION
Isolated TypeScript major upgrade split out from the grouped Dependabot update in #56.

## Updates
| Package | From | To |
| --- | --- | --- |
| typescript | 5.9.3 | 6.0.3 |

## Config change
TypeScript 6 promotes the deprecation of `moduleResolution: "node"` (node10) into a hard error (`TS5107`). This project is a CommonJS build bundled by webpack/ts-loader, where node10 resolution is the correct choice, so I've added `"ignoreDeprecations": "6.0"` to `tsconfig.json` — the exact migration path the compiler error recommends. This keeps module-resolution behavior byte-for-byte identical.

A proper migration to `node16`/`nodenext`/`bundler` resolution (which would require `.js` import extensions and other changes) is deliberately **out of scope** here and can be tackled as its own change before TypeScript 7 removes node10 support.

## Verification
Local (Node 22, npm 11): `npm ci` ✓, `npm run build` ✓, `npm run lint` ✓, `vitest run` ✓ — 164/167; the 3 failures are `EAFNOSUPPORT ::1` from the sandbox lacking IPv6 loopback, unrelated. CI runs on Node 24.

Part of splitting up #56.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpzAhm1Ht6KWWNF44EVDRK)_