### PR TITLE
chore(release): bump version to 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Both `o2f-server` and `o2f-client` support the following command line options:
 Example:
 ```bash
 o2f-server --version
-# Output: o2f-server v1.5.1
+# Output: o2f-server v1.6.0
 ```
 
 ## Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oauth2-forwarder",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oauth2-forwarder",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2-forwarder",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "utilities for forwarding oauth2 interactive flow (e.g. container to host)",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Minor version bump `1.5.1` → `1.6.0`.

## Why minor
`main` has taken on a full round of toolchain major upgrades since 1.5.1 — eslint 10, typescript 6, vitest 4, webpack-cli 7, plus @types/node 26 and assorted patch/minor bumps (nanoid, prettier, webpack, typescript-eslint) and the CI action upgrades (checkout v7, setup-node v6). These are dev/build-tooling changes with no change to the shipped CLI's runtime behavior, so a minor bump (not major) is appropriate.

## Changes
Mirrors the previous release commit's footprint:
- `package.json` — `version` → 1.6.0
- `package-lock.json` — root + root-package `version` → 1.6.0
- `README.md` — `--version` example output → `v1.6.0`

## Verification
On `main` with all upgrades merged: `npm run build` ✓, `npm run lint` ✓, tests 164/167 (the 3 failures are `EAFNOSUPPORT ::1` from the sandbox lacking IPv6 loopback — they pass on CI runners), `npm audit` 0 vulnerabilities.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpzAhm1Ht6KWWNF44EVDRK)_